### PR TITLE
feat: Implementa tratamento de erro de negócio 'CEP Não Encontrado'

### DIFF
--- a/consulta-cep/src/main/java/com/cep/CepNotFoundException.java
+++ b/consulta-cep/src/main/java/com/cep/CepNotFoundException.java
@@ -1,0 +1,11 @@
+package com.cep;
+
+public class CepNotFoundException extends Exception {
+  public CepNotFoundException(String message) {
+    super(message);
+  }
+
+  public CepNotFoundException() {
+    super("O cep fornecido não foi encontrado");
+  }
+}

--- a/consulta-cep/src/main/java/com/cep/EnderecoDTO.java
+++ b/consulta-cep/src/main/java/com/cep/EnderecoDTO.java
@@ -19,6 +19,13 @@ public class EnderecoDTO {
   private String ddd;
   private String siafi;
 
+  @JsonProperty("erro")
+  private boolean erro;
+
+  public boolean isErro() {
+    return erro;
+  }
+
   public EnderecoDTO() {
   }
 
@@ -34,6 +41,7 @@ public class EnderecoDTO {
     this.gia = gia;
     this.ddd = ddd;
     this.siafi = siafi;
+
   }
 
   public String getCep() {
@@ -126,5 +134,9 @@ public class EnderecoDTO {
         "  Bairro: " + bairro + "\n" +
         "  Localidade/UF: " + localidade + "/" + uf + "\n" +
         "  Complemento: " + comp;
+  }
+
+  public void setErro(boolean erro) {
+    this.erro = erro;
   }
 }


### PR DESCRIPTION
Fecha a Issue #2.

Este Pull Request implementa uma solução robusta para o tratamento do erro de negócio específico da ViaCEP, onde a resposta JSON contém a flag `"erro": true` para um CEP que não foi encontrado na base de dados.

O objetivo é garantir que a aplicação não falhe com objetos vazios e que o usuário receba um feedback claro e não técnico sobre o problema.

---

## Detalhes das Alterações

As seguintes mudanças foram realizadas, conforme os Critérios de Aceitação:

1.  **Criação de `CepNotFoundException`:** Uma exceção customizada de negócio foi criada para isolar o erro de "CEP Não Encontrado" dos erros de I/O ou rede.
2.  **Atualização do DTO:** O `EnderecoDTO` foi atualizado para desserializar corretamente a flag `"erro"` (boolean) da resposta JSON da ViaCEP.
3.  **Lançamento da Exceção:** No método `lerJson`, após o *parsing*, a flag `isErro()` é verificada e a `CepNotFoundException` é lançada, garantindo que a regra de negócio seja aplicada na camada de serviço.
4.  **Tratamento no Ponto de Entrada:** O método `main` agora utiliza um bloco `try-catch` específico para a `CepNotFoundException`, fornecendo a mensagem amigável e orientativa ao usuário.

## Valor de Engenharia

Com esta implementação, a aplicação atinge maior **robustez** e proporciona uma **melhor experiência do usuário**, fornecendo *feedback* claro e não interrompendo abruptamente o fluxo por falhas não tratadas.

## Como Testar

Para validar a solução, por favor, realize os seguintes testes:

1.  **Caminho Feliz (Sucesso):** Digite um CEP válido (ex: `01001000`).
2.  **Caminho Infeliz (Erro de Negócio):** Digite um CEP que não existe, mas está no formato correto (ex: `99999999`). A aplicação deve capturar a exceção e exibir a mensagem amigável.
3.  **Caminho Infeliz (Erro HTTP):** Digite um CEP inválido no formato (ex: `123`), para verificar se o tratamento de `IOException` (Status 400) também está funcionando.
